### PR TITLE
FreeBSD: Do not mention -s in the information section

### DIFF
--- a/nfsdtop.freebsd
+++ b/nfsdtop.freebsd
@@ -8,7 +8,7 @@
 #
 ############################################################ INFORMATION
 #
-# In nfsdtop, a ``view'' is the user's choice between -c, -g, -s, or -u.
+# In nfsdtop, a ``view'' is the user's choice between -c, -g, or -u.
 # For example, `-u' asks nfsdtop to display the ``user view'' where statistics
 # displayed are on a per-user basis.
 #


### PR DESCRIPTION
The FreeBSD version of nfsdtop does not support -s at this point.

Fixes: 9438e29d28c324b5655262569c95c6ebae15a7e4